### PR TITLE
Ensure security validator uses context commands and consolidate context

### DIFF
--- a/mcp_validation/__init__.py
+++ b/mcp_validation/__init__.py
@@ -16,7 +16,7 @@ from .config.settings import (
     ValidatorConfig,
     load_config_from_env,
 )
-from .core.result import MCPValidationResult, ValidationContext, ValidationSession, ValidatorResult
+from .core.result import MCPValidationResult, ValidationSession, ValidatorResult
 from .core.transport import JSONRPCTransport
 
 # Core components
@@ -27,7 +27,7 @@ from .reporting.console import ConsoleReporter
 from .reporting.json_report import JSONReporter
 
 # Validator framework
-from .validators.base import BaseValidator
+from .validators.base import BaseValidator, ValidationContext
 
 __version__ = "2.0.0"
 

--- a/mcp_validation/core/result.py
+++ b/mcp_validation/core/result.py
@@ -35,18 +35,6 @@ class ValidatorResult:
     data: Dict[str, Any]
     execution_time: float
 
-
-@dataclass
-class ValidationContext:
-    """Context passed to validators containing process and shared state."""
-
-    process: Any  # asyncio.subprocess.Process
-    server_info: Dict[str, Any]
-    capabilities: Dict[str, Any]
-    timeout: float = 30.0
-    transport: Any = None  # JSONRPCTransport
-
-
 @dataclass
 class ValidationSession:
     """Complete validation session result."""

--- a/mcp_validation/reporting/console.py
+++ b/mcp_validation/reporting/console.py
@@ -140,9 +140,12 @@ class ConsoleReporter:
         """Report security validation specific data."""
         tools_scanned = data.get("tools_scanned", 0)
         vulnerabilities_found = data.get("vulnerabilities_found", 0)
+        issues_found = data.get("issues_found", 0)
 
-        if vulnerabilities_found > 0:
-            print(f"    🔍 Security: {vulnerabilities_found} issues found in {tools_scanned} tools")
+        total_issues = vulnerabilities_found + issues_found
+
+        if total_issues > 0:
+            print(f"    🔍 Security: {total_issues} issues found in {tools_scanned} tools")
 
             # Show vulnerability types if available
             vuln_types = data.get("vulnerability_types", [])
@@ -150,7 +153,15 @@ class ConsoleReporter:
                 types_str = ", ".join(vuln_types[:3])
                 if len(vuln_types) > 3:
                     types_str += f" (and {len(vuln_types) - 3} more)"
-                print(f"        🚨 Issues: {types_str}")
+                print(f"        🚨 Vulnerabilities: {types_str}")
+
+            # Show issue codes if available
+            issue_codes = data.get("issue_codes", [])
+            if issue_codes:
+                codes_str = ", ".join(issue_codes[:3])
+                if len(issue_codes) > 3:
+                    codes_str += f" (and {len(issue_codes) - 3} more)"
+                print(f"        🚨 Issues: {codes_str}")
         else:
             print(f"    🔍 Security: No issues found in {tools_scanned} tools")
 

--- a/mcp_validation/reporting/json_report.py
+++ b/mcp_validation/reporting/json_report.py
@@ -114,6 +114,9 @@ class JSONReporter:
                 "vulnerabilities_found": security_analysis.get("vulnerabilities_found", 0),
                 "vulnerability_types": security_analysis.get("vulnerability_types", []),
                 "risk_levels": security_analysis.get("risk_levels", []),
+                "issues_found": security_analysis.get("issues_found", 0),
+                "issue_codes": security_analysis.get("issue_codes", []),
+                "issues": security_analysis.get("issues", []),
                 "scan_file": security_analysis.get("scan_file"),
             },
             "repository_validation": {

--- a/mcp_validation/validators/base.py
+++ b/mcp_validation/validators/base.py
@@ -4,7 +4,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
-
+from ..core.transport import JSONRPCTransport
 
 @dataclass
 class ValidationContext:
@@ -15,6 +15,7 @@ class ValidationContext:
     capabilities: Dict[str, Any]
     timeout: float = 30.0
     command_args: Optional[List[str]] = None
+    transport: Optional[JSONRPCTransport] = None
 
 
 @dataclass

--- a/mcp_validation/validators/errors.py
+++ b/mcp_validation/validators/errors.py
@@ -63,7 +63,7 @@ class ErrorComplianceValidator(BaseValidator):
     ) -> None:
         """Test error response for invalid method calls."""
         try:
-            response = await context.transport.send_and_receive(
+            response: Dict[str, Any] = await context.transport.send_and_receive(
                 "invalid_method_that_does_not_exist",
                 params={},
                 timeout=self.config.get("timeout", 5.0),

--- a/mcp_validation/validators/security.py
+++ b/mcp_validation/validators/security.py
@@ -77,11 +77,12 @@ class SecurityValidator(BaseValidator):
                 # Parse scan results
                 tools_scanned, vulnerabilities = self._parse_scan_results(scan_results)
                 data["tools_scanned"] = tools_scanned
-                data["vulnerabilities_found"] = len(vulnerabilities)
-                data["vulnerability_types"] = list(
-                    {v.get("type", "unknown") for v in vulnerabilities}
-                )
-                data["risk_levels"] = list({v.get("severity", "unknown") for v in vulnerabilities})
+                if len(vulnerabilities) > 0:
+                    data["vulnerabilities_found"] = len(vulnerabilities)
+                    data["vulnerability_types"] = list(
+                        {v.get("type", "unknown") for v in vulnerabilities}
+                    )
+                    data["risk_levels"] = list({v.get("severity", "unknown") for v in vulnerabilities})
 
                 # Check vulnerability threshold
                 threshold = self.config.get("vulnerability_threshold", "high")
@@ -109,13 +110,11 @@ class SecurityValidator(BaseValidator):
 
         # Create temporary MCP configuration file for mcp-scan
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as config_file:
-            # Get command from context (need to reconstruct from process)
-            # For now, use a simplified approach
             config = {
                 "mcpServers": {
                     "test-server": {
-                        "command": "echo",  # Placeholder - this needs the actual command
-                        "args": ["MCP server placeholder"],
+                        "command": context.command_args[0],
+                        "args": context.command_args[1:],
                     }
                 }
             }


### PR DESCRIPTION
- Fixes a bug in SecurityValidator where the mcp server configuration uses placeholder commands instead of contextual commands and arguments. 
- De-duplicates ValidationContext, and consolidates class fields.
- Fixes a bug in processing vulnerabilities reported via mcp-scan where the underlying data reports no vulnerabilities (either legitimately or due to an error)

Fixes #2
Fixes #3